### PR TITLE
Handle metadata after filenames

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ license = "MIT"
 
 [dependencies]
 nom = "^1.2.4"
+chrono = "^0.2.25"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ extern crate chrono;
 use std::error::Error;
 use nom::{IResult, Err};
 
-pub use self::parser::{Patch};
+pub use self::parser::{Patch, File, FileMetadata};
 use self::parser::{patch};
 
 mod parser;
@@ -43,12 +43,10 @@ impl Error for PatchError {
 
 pub fn parse(diff: &str) -> Result<Patch, PatchError> {
     match patch(diff.as_bytes()) {
-        IResult::Done(_, (((old, old_timestamp), (new, new_timestamp)), hunks, no_newline)) =>
+        IResult::Done(_, ((old, new), hunks, no_newline)) =>
             Ok(Patch {
                 old: old,
                 new: new,
-                old_timestamp: old_timestamp,
-                new_timestamp: new_timestamp,
                 hunks: hunks,
                 no_newline: no_newline,
             }),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 
 #[macro_use]
 extern crate nom;
+extern crate chrono;
 
 use std::error::Error;
 use nom::{IResult, Err};
@@ -42,10 +43,12 @@ impl Error for PatchError {
 
 pub fn parse(diff: &str) -> Result<Patch, PatchError> {
     match patch(diff.as_bytes()) {
-        IResult::Done(_, ((old, new), hunks, no_newline)) =>
+        IResult::Done(_, (((old, old_timestamp), (new, new_timestamp)), hunks, no_newline)) =>
             Ok(Patch {
                 old: old,
                 new: new,
+                old_timestamp: old_timestamp,
+                new_timestamp: new_timestamp,
                 hunks: hunks,
                 no_newline: no_newline,
             }),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -99,9 +99,10 @@ named!(header_line_content<File>,
             meta: {
                 if after.is_empty() {
                     None
+                } else if let Ok(dt) = DateTime::parse_from_str(after, "%F %T%.f %z").or_else(|_| DateTime::parse_from_str(after, "%F %T %z")) {
+                    Some(FileMetadata::DateTime(dt))
                 } else {
-                    Some(DateTime::parse_from_str(after, "%F %T%.f %z").or_else(|_| DateTime::parse_from_str(after, "%F %T %z")).map(FileMetadata::DateTime).ok()
-                        .unwrap_or_else(|| FileMetadata::Other(after)))
+                    Some(FileMetadata::Other(after))
                 }
             },
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -84,7 +84,7 @@ named!(header_line_content<(String, Option<DateTime<FixedOffset>>)>,
             std::str::from_utf8
         ) ,
 
-        || (filename, DateTime::parse_from_str(after, "%F %T%.f %z").ok())
+        || (filename, DateTime::parse_from_str(after, "%F %T%.f %z").or_else(|_| DateTime::parse_from_str(after, "%F %T %z")).ok())
     )
 );
 
@@ -249,6 +249,9 @@ fn test_fname() {
 fn test_header_line_contents() {
     assert_eq!(header_line_content("lao 2002-02-21 23:30:39.942229878 -0800\n".as_bytes()),
         IResult::Done("\n".as_bytes(), ("lao".to_string(), DateTime::parse_from_rfc3339("2002-02-21T23:30:39.942229878-08:00").ok())));
+
+    assert_eq!(header_line_content("lao 2002-02-21 23:30:39 -0800\n".as_bytes()),
+        IResult::Done("\n".as_bytes(), ("lao".to_string(), DateTime::parse_from_rfc3339("2002-02-21T23:30:39-08:00").ok())));
 
     assert_eq!(header_line_content("lao\n".as_bytes()),
         IResult::Done("\n".as_bytes(), ("lao".to_string(), None)));

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,4 +1,5 @@
 extern crate patch;
+extern crate chrono;
 
 #[test]
 fn test_parse() {
@@ -45,6 +46,34 @@ fn test_parse_no_newline() {
             assert_eq!(&p.old, "before.py");
             assert_eq!(&p.new, "after.py");
             assert_eq!(p.no_newline, false);
+        },
+        Err(e) => {
+            println!("{:?}", e);
+            panic!("failed to parse sample patch");
+        },
+    }
+}
+
+#[test]
+fn test_parse_timestamps() {
+    let sample = "\
+--- before.py 2002-02-21 23:30:39.942229878 -0800
++++ after.py 2002-02-21 23:30:50.442260588 -0800
+@@ -1,4 +1,4 @@
+-bacon
+-eggs
+-ham
++python
++eggy
++hamster
+ guido\n";
+    match patch::parse(sample) {
+        Ok(p) => {
+            assert_eq!(&p.old, "before.py");
+            assert_eq!(&p.new, "after.py");
+            assert_eq!(p.old_timestamp.unwrap(), chrono::DateTime::parse_from_rfc3339("2002-02-21T23:30:39.942229878-08:00").unwrap());
+            assert_eq!(p.new_timestamp.unwrap(), chrono::DateTime::parse_from_rfc3339("2002-02-21T23:30:50.442260588-08:00").unwrap());
+            assert_eq!(p.no_newline, true);
         },
         Err(e) => {
             println!("{:?}", e);

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -16,8 +16,14 @@ fn test_parse() {
  guido\n";
     match patch::parse(sample) {
         Ok(p) => {
-            assert_eq!(&p.old, "before.py");
-            assert_eq!(&p.new, "after.py");
+            assert_eq!(p.old, patch::File {
+                name: "before.py".to_string(),
+                meta: None,
+            });
+            assert_eq!(p.new, patch::File {
+                name: "after.py".to_string(),
+                meta: None,
+            });
             assert_eq!(p.no_newline, true);
         },
         Err(e) => {
@@ -43,8 +49,14 @@ fn test_parse_no_newline() {
 \\ No newline at end of file";
     match patch::parse(sample) {
         Ok(p) => {
-            assert_eq!(&p.old, "before.py");
-            assert_eq!(&p.new, "after.py");
+            assert_eq!(p.old, patch::File {
+                name: "before.py".to_string(),
+                meta: None,
+            });
+            assert_eq!(p.new, patch::File {
+                name: "after.py".to_string(),
+                meta: None,
+            });
             assert_eq!(p.no_newline, false);
         },
         Err(e) => {
@@ -69,10 +81,46 @@ fn test_parse_timestamps() {
  guido\n";
     match patch::parse(sample) {
         Ok(p) => {
-            assert_eq!(&p.old, "before.py");
-            assert_eq!(&p.new, "after.py");
-            assert_eq!(p.old_timestamp.unwrap(), chrono::DateTime::parse_from_rfc3339("2002-02-21T23:30:39.942229878-08:00").unwrap());
-            assert_eq!(p.new_timestamp.unwrap(), chrono::DateTime::parse_from_rfc3339("2002-02-21T23:30:50-08:00").unwrap());
+            assert_eq!(p.old, patch::File {
+                name: "before.py".to_string(),
+                meta: Some(patch::FileMetadata::DateTime(chrono::DateTime::parse_from_rfc3339("2002-02-21T23:30:39.942229878-08:00").unwrap())),
+            });
+            assert_eq!(p.new, patch::File {
+                name: "after.py".to_string(),
+                meta: Some(patch::FileMetadata::DateTime(chrono::DateTime::parse_from_rfc3339("2002-02-21T23:30:50-08:00").unwrap())),
+            });
+            assert_eq!(p.no_newline, true);
+        },
+        Err(e) => {
+            println!("{:?}", e);
+            panic!("failed to parse sample patch");
+        },
+    }
+}
+
+#[test]
+fn test_parse_other() {
+    let sample = "\
+--- before.py 08f78e0addd5bf7b7aa8887e406493e75e8d2b55
++++ after.py e044048282ce75186ecc7a214fd3d9ba478a2816
+@@ -1,4 +1,4 @@
+-bacon
+-eggs
+-ham
++python
++eggy
++hamster
+ guido\n";
+    match patch::parse(sample) {
+        Ok(p) => {
+            assert_eq!(p.old, patch::File {
+                name: "before.py".to_string(),
+                meta: Some(patch::FileMetadata::Other("08f78e0addd5bf7b7aa8887e406493e75e8d2b55")),
+            });
+            assert_eq!(p.new, patch::File {
+                name: "after.py".to_string(),
+                meta: Some(patch::FileMetadata::Other("e044048282ce75186ecc7a214fd3d9ba478a2816")),
+            });
             assert_eq!(p.no_newline, true);
         },
         Err(e) => {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -58,7 +58,7 @@ fn test_parse_no_newline() {
 fn test_parse_timestamps() {
     let sample = "\
 --- before.py 2002-02-21 23:30:39.942229878 -0800
-+++ after.py 2002-02-21 23:30:50.442260588 -0800
++++ after.py 2002-02-21 23:30:50 -0800
 @@ -1,4 +1,4 @@
 -bacon
 -eggs
@@ -72,7 +72,7 @@ fn test_parse_timestamps() {
             assert_eq!(&p.old, "before.py");
             assert_eq!(&p.new, "after.py");
             assert_eq!(p.old_timestamp.unwrap(), chrono::DateTime::parse_from_rfc3339("2002-02-21T23:30:39.942229878-08:00").unwrap());
-            assert_eq!(p.new_timestamp.unwrap(), chrono::DateTime::parse_from_rfc3339("2002-02-21T23:30:50.442260588-08:00").unwrap());
+            assert_eq!(p.new_timestamp.unwrap(), chrono::DateTime::parse_from_rfc3339("2002-02-21T23:30:50-08:00").unwrap());
             assert_eq!(p.no_newline, true);
         },
         Err(e) => {


### PR DESCRIPTION
Since they're in the [official example](https://www.gnu.org/software/diffutils/manual/html_node/Example-Unified.html#Example-Unified), 'twould be a shame to ignore them