### PR TITLE
Capture text after range info

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -216,13 +216,15 @@ pub struct Hunk<'a> {
     pub old_range: Range,
     /// The range of lines in the new file that this hunk represents
     pub new_range: Range,
+    /// Any trailing text after the hunk's range information
+    pub range_text: String,
     /// Each line of text in the hunk, prefixed with the type of change it represents
     pub lines: Vec<Line<'a>>,
 }
 
 impl<'a> fmt::Display for Hunk<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "@@ -{} +{} @@", self.old_range, self.new_range)?;
+        write!(f, "@@ -{} +{} @@{}", self.old_range, self.new_range, self.range_text)?;
 
         for line in &self.lines {
             write!(f, "\n{}", line)?;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -156,26 +156,27 @@ fn chunk(input: Input<'_>) -> IResult<Input<'_>, Hunk> {
     let (input, ranges) = chunk_header(input)?;
     let (input, lines) = many1(chunk_line)(input)?;
 
-    let (old_range, new_range) = ranges;
+    let (old_range, new_range, range_text) = ranges;
     Ok((
         input,
         Hunk {
             old_range,
             new_range,
+            range_text,
             lines,
         },
     ))
 }
 
-fn chunk_header(input: Input<'_>) -> IResult<Input<'_>, (Range, Range)> {
+fn chunk_header(input: Input<'_>) -> IResult<Input<'_>, (Range, Range, String)> {
     let (input, _) = tag("@@ -")(input)?;
     let (input, old_range) = range(input)?;
     let (input, _) = tag(" +")(input)?;
     let (input, new_range) = range(input)?;
     let (input, _) = tag(" @@")(input)?;
-    // Ignore any additional context provied after @@ (git sometimes adds this)
-    let (input, _) = many0(newline)(input)?;
-    Ok((input, (old_range, new_range)))
+    let (input, range_text) = take_till(|c| c == '\n')(input)?;
+    let (input, _) = newline(input)?;
+    Ok((input, (old_range, new_range, range_text.to_string())))
 }
 
 fn range(input: Input<'_>) -> IResult<Input<'_>, Range> {
@@ -434,9 +435,10 @@ mod tests {
 
     #[test]
     fn test_chunk_header() -> ParseResult<'static, ()> {
-        test_parser!(chunk_header("@@ -1,7 +1,6 @@\n") -> (
+        test_parser!(chunk_header("@@ -1,7 +1,6 @@ foo bar\n") -> (
             Range { start: 1, count: 7 },
             Range { start: 1, count: 6 },
+            " foo bar".into(),
         ));
         Ok(())
     }
@@ -457,6 +459,7 @@ mod tests {
         let expected = Hunk {
             old_range: Range { start: 1, count: 7 },
             new_range: Range { start: 1, count: 6 },
+            range_text: "".into(),
             lines: vec![
                 Line::Remove("The Way that can be told of is not the eternal Way;"),
                 Line::Remove("The name that can be named is not the eternal name."),
@@ -514,6 +517,7 @@ mod tests {
                 Hunk {
                     old_range: Range { start: 1, count: 7 },
                     new_range: Range { start: 1, count: 6 },
+                    range_text: "".into(),
                     lines: vec![
                         Line::Remove("The Way that can be told of is not the eternal Way;"),
                         Line::Remove("The name that can be named is not the eternal name."),
@@ -529,6 +533,7 @@ mod tests {
                 Hunk {
                     old_range: Range { start: 9, count: 3 },
                     new_range: Range { start: 8, count: 6 },
+                    range_text: "".into(),
                     lines: vec![
                         Line::Context("The two are the same,"),
                         Line::Context("But after they are produced,"),


### PR DESCRIPTION
This was previously intentionally ignored. I find having this text
useful if only to make it so that any patches I read can be written out
and match the original exactly.