### PR TITLE
Bump to Nom 7, format, fixup errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,9 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
-nom = "5.0"
-nom_locate = "1.0.0"
-chrono = "0.4"
+nom = "7.1.0"
+nom_locate = "4.0.0"
+chrono = "0.4.19"
 
 [dev-dependencies]
-pretty_assertions = "0.5"
+pretty_assertions = "1.0.0"

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,9 +1,9 @@
-use std::fmt;
 use std::borrow::Cow;
+use std::fmt;
 
 use chrono::{DateTime, FixedOffset};
 
-use crate::parser::{parse_single_patch, parse_multiple_patches, ParseError};
+use crate::parser::{parse_multiple_patches, parse_single_patch, ParseError};
 
 /// A complete patch summarizing the differences between two files
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -135,13 +135,9 @@ impl<'a> Patch<'a> {
 }
 
 /// Check if a string needs to be quoted, and format it accordingly
-fn maybe_escape_quote(f: &mut fmt::Formatter, s: &Cow<str>) -> fmt::Result {
-    let should_quote = |ch| match ch {
-        ' ' | '\t' | '\r' | '\n' | '\"' | '\0' | '\\' => true,
-        _ => false,
-    };
+fn maybe_escape_quote(f: &mut fmt::Formatter, s: &str) -> fmt::Result {
+    let quote = s.chars().any(|ch| matches!(ch, ' ' | '\t' | '\r' | '\n' | '\"' | '\0' | '\\'));
 
-    let quote = s.chars().any(should_quote);
     if quote {
         write!(f, "\"")?;
         for ch in s.chars() {
@@ -204,9 +200,8 @@ impl<'a> fmt::Display for FileMetadata<'a> {
         match self {
             FileMetadata::DateTime(datetime) => {
                 write!(f, "{}", datetime.format("%F %T%.f %z"))
-            },
-            FileMetadata::Other(data) => maybe_escape_quote(f, data)
-,
+            }
+            FileMetadata::Other(data) => maybe_escape_quote(f, data),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,8 +45,8 @@
 
 #![deny(unused_must_use)]
 
-mod parser;
 mod ast;
+mod parser;
 
-pub use parser::ParseError;
 pub use ast::*;
+pub use parser::ParseError;

--- a/tests/parse_patch.rs
+++ b/tests/parse_patch.rs
@@ -1,5 +1,5 @@
 use chrono::DateTime;
-use patch::{Patch, File, FileMetadata, ParseError};
+use patch::{File, FileMetadata, ParseError, Patch};
 
 use pretty_assertions::assert_eq;
 
@@ -17,8 +17,20 @@ fn test_parse() -> Result<(), ParseError<'static>> {
 +hamster
  guido\n";
     let patch = Patch::from_single(sample)?;
-    assert_eq!(patch.old, File {path: "before.py".into(), meta: None});
-    assert_eq!(patch.new, File {path: "after.py".into(), meta: None});
+    assert_eq!(
+        patch.old,
+        File {
+            path: "before.py".into(),
+            meta: None
+        }
+    );
+    assert_eq!(
+        patch.new,
+        File {
+            path: "after.py".into(),
+            meta: None
+        }
+    );
     assert_eq!(patch.end_newline, true);
 
     assert_eq!(format!("{}\n", patch), sample);
@@ -41,8 +53,20 @@ fn test_parse_no_newline_indicator() -> Result<(), ParseError<'static>> {
  guido
 \\ No newline at end of file\n";
     let patch = Patch::from_single(sample)?;
-    assert_eq!(patch.old, File {path: "before.py".into(), meta: None});
-    assert_eq!(patch.new, File {path: "after.py".into(), meta: None});
+    assert_eq!(
+        patch.old,
+        File {
+            path: "before.py".into(),
+            meta: None
+        }
+    );
+    assert_eq!(
+        patch.new,
+        File {
+            path: "after.py".into(),
+            meta: None
+        }
+    );
     assert_eq!(patch.end_newline, false);
 
     assert_eq!(format!("{}\n", patch), sample);
@@ -65,18 +89,24 @@ fn test_parse_timestamps() -> Result<(), ParseError<'static>> {
  guido
 \\ No newline at end of file";
     let patch = Patch::from_single(sample)?;
-    assert_eq!(patch.old, File {
-        path: "before.py".into(),
-        meta: Some(FileMetadata::DateTime(
-            DateTime::parse_from_rfc3339("2002-02-21T23:30:39.942229878-08:00").unwrap()
-        )),
-    });
-    assert_eq!(patch.new, File {
-        path: "after.py".into(),
-        meta: Some(FileMetadata::DateTime(
-            DateTime::parse_from_rfc3339("2002-02-21T23:30:50-08:00").unwrap()
-        )),
-    });
+    assert_eq!(
+        patch.old,
+        File {
+            path: "before.py".into(),
+            meta: Some(FileMetadata::DateTime(
+                DateTime::parse_from_rfc3339("2002-02-21T23:30:39.942229878-08:00").unwrap()
+            )),
+        }
+    );
+    assert_eq!(
+        patch.new,
+        File {
+            path: "after.py".into(),
+            meta: Some(FileMetadata::DateTime(
+                DateTime::parse_from_rfc3339("2002-02-21T23:30:50-08:00").unwrap()
+            )),
+        }
+    );
     assert_eq!(patch.end_newline, false);
 
     // to_string() uses Display but adds no trailing newline
@@ -99,14 +129,24 @@ fn test_parse_other() -> Result<(), ParseError<'static>> {
 +hamster
  guido\n";
     let patch = Patch::from_single(sample)?;
-    assert_eq!(patch.old, File {
-        path: "before.py".into(),
-        meta: Some(FileMetadata::Other("08f78e0addd5bf7b7aa8887e406493e75e8d2b55".into())),
-    });
-    assert_eq!(patch.new, File {
-        path: "after.py".into(),
-        meta: Some(FileMetadata::Other("e044048282ce75186ecc7a214fd3d9ba478a2816".into())),
-    });
+    assert_eq!(
+        patch.old,
+        File {
+            path: "before.py".into(),
+            meta: Some(FileMetadata::Other(
+                "08f78e0addd5bf7b7aa8887e406493e75e8d2b55".into()
+            )),
+        }
+    );
+    assert_eq!(
+        patch.new,
+        File {
+            path: "after.py".into(),
+            meta: Some(FileMetadata::Other(
+                "e044048282ce75186ecc7a214fd3d9ba478a2816".into()
+            )),
+        }
+    );
     assert_eq!(patch.end_newline, true);
 
     assert_eq!(format!("{}\n", patch), sample);
@@ -128,14 +168,22 @@ fn test_parse_escaped() -> Result<(), ParseError<'static>> {
 +hamster
  guido\n";
     let patch = Patch::from_single(sample)?;
-    assert_eq!(patch.old, File {
-        path: "before.py".into(),
-        meta: Some(FileMetadata::Other("asdf \\ \n \t \0 \r \" ".into())),
-    });
-    assert_eq!(patch.new, File {
-        path: "My Work/after.py".into(),
-        meta: Some(FileMetadata::Other("My project is cool! Wow!!; SELECT * FROM USERS;".into())),
-    });
+    assert_eq!(
+        patch.old,
+        File {
+            path: "before.py".into(),
+            meta: Some(FileMetadata::Other("asdf \\ \n \t \0 \r \" ".into())),
+        }
+    );
+    assert_eq!(
+        patch.new,
+        File {
+            path: "My Work/after.py".into(),
+            meta: Some(FileMetadata::Other(
+                "My project is cool! Wow!!; SELECT * FROM USERS;".into()
+            )),
+        }
+    );
     assert_eq!(patch.end_newline, true);
 
     assert_eq!(format!("{}\n", patch), sample);
@@ -164,8 +212,20 @@ fn test_parse_triple_plus_minus() -> Result<(), ParseError<'static>> {
     assert_eq!(patches.len(), 1);
 
     let patch = &patches[0];
-    assert_eq!(patch.old, File {path: "main.c".into(), meta: None});
-    assert_eq!(patch.new, File {path: "main.c".into(), meta: None});
+    assert_eq!(
+        patch.old,
+        File {
+            path: "main.c".into(),
+            meta: None
+        }
+    );
+    assert_eq!(
+        patch.new,
+        File {
+            path: "main.c".into(),
+            meta: None
+        }
+    );
     assert_eq!(patch.end_newline, true);
 
     assert_eq!(patch.hunks.len(), 1);
@@ -204,8 +264,20 @@ fn test_parse_triple_plus_minus_hack() {
     assert_eq!(patches.len(), 1);
 
     let patch = &patches[0];
-    assert_eq!(patch.old, File {path: "main.c".into(), meta: None});
-    assert_eq!(patch.new, File {path: "main.c".into(), meta: None});
+    assert_eq!(
+        patch.old,
+        File {
+            path: "main.c".into(),
+            meta: None
+        }
+    );
+    assert_eq!(
+        patch.new,
+        File {
+            path: "main.c".into(),
+            meta: None
+        }
+    );
     assert_eq!(patch.end_newline, true);
 
     assert_eq!(patch.hunks.len(), 1);

--- a/tests/parse_samples.rs
+++ b/tests/parse_samples.rs
@@ -15,17 +15,19 @@ fn parse_samples() {
         }
 
         let data = fs::read_to_string(dbg!(&path)).unwrap();
-        let patches = Patch::from_multiple(&data).unwrap_or_else(
-            |err| panic!("failed to parse {:?}, error: {}", path, err)
-        );
+        let patches = Patch::from_multiple(&data)
+            .unwrap_or_else(|err| panic!("failed to parse {:?}, error: {}", path, err));
 
         // Make sure that the patch file we produce parses to the same information as the original
         // patch file.
         let patch_file: String = patches.iter().map(|patch| format!("{}\n", patch)).collect();
         println!("{}", patch_file);
-        let patches2 = Patch::from_multiple(&patch_file).unwrap_or_else(
-            |err| panic!("failed to re-parse {:?} after formatting, error: {}", path, err)
-        );
+        let patches2 = Patch::from_multiple(&patch_file).unwrap_or_else(|err| {
+            panic!(
+                "failed to re-parse {:?} after formatting, error: {}",
+                path, err
+            )
+        });
         assert_eq!(patches, patches2);
     }
 }


### PR DESCRIPTION
Changes to patch-rs to make it compile and work with `nom = "7.1.0"`!