### PR TITLE
Fix trailing hunk header text

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -216,13 +216,23 @@ pub struct Hunk<'a> {
     pub old_range: Range,
     /// The range of lines in the new file that this hunk represents
     pub new_range: Range,
+    /// Any trailing text after the hunk's range information
+    pub range_hint: &'a str,
     /// Each line of text in the hunk, prefixed with the type of change it represents
     pub lines: Vec<Line<'a>>,
 }
 
+impl<'a> Hunk<'_> {
+    /// A nicer way to access the optional hint
+    pub fn hint(&self) -> Option<&str> {
+        let h = self.range_hint.trim_start();
+        if h.len() > 0 { Some(h) } else { None }
+    }
+}
+
 impl<'a> fmt::Display for Hunk<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "@@ -{} +{} @@", self.old_range, self.new_range)?;
+        write!(f, "@@ -{} +{} @@{}", self.old_range, self.new_range, self.range_hint)?;
 
         for line in &self.lines {
             write!(f, "\n{}", line)?;
@@ -264,6 +274,35 @@ impl<'a> fmt::Display for Line<'a> {
             Line::Add(line) => write!(f, "+{}", line),
             Line::Remove(line) => write!(f, "-{}", line),
             Line::Context(line) => write!(f, " {}", line),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test_hint_helper() {
+        let mut h = Hunk {
+            old_range: Range { start: 0, count: 0 },
+            new_range: Range { start: 0, count: 0 },
+            range_hint: "",
+            lines: vec![],
+        };
+        for (input, expected) in vec![
+            ("", None),
+            (" ", None),
+            ("  ", None),
+            ("x", Some("x")),
+            (" x", Some("x")),
+            ("x ", Some("x ")),
+            (" x ", Some("x ")),
+            ("  abc def ", Some("abc def ")),
+        ] {
+            h.range_hint = input;
+            assert_eq!(h.hint(), expected);
         }
     }
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -222,17 +222,25 @@ pub struct Hunk<'a> {
     pub lines: Vec<Line<'a>>,
 }
 
-impl<'a> Hunk<'_> {
+impl<'a> Hunk<'a> {
     /// A nicer way to access the optional hint
     pub fn hint(&self) -> Option<&str> {
         let h = self.range_hint.trim_start();
-        if h.len() > 0 { Some(h) } else { None }
+        if h.is_empty() {
+            None
+        } else {
+            Some(h)
+        }
     }
 }
 
 impl<'a> fmt::Display for Hunk<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "@@ -{} +{} @@{}", self.old_range, self.new_range, self.range_hint)?;
+        write!(
+            f,
+            "@@ -{} +{} @@{}",
+            self.old_range, self.new_range, self.range_hint
+        )?;
 
         for line in &self.lines {
             write!(f, "\n{}", line)?;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -174,7 +174,8 @@ fn chunk_header(input: Input<'_>) -> IResult<Input<'_>, (Range, Range)> {
     let (input, new_range) = range(input)?;
     let (input, _) = tag(" @@")(input)?;
     // Ignore any additional context provied after @@ (git sometimes adds this)
-    let (input, _) = many0(newline)(input)?;
+    let (input, _) = take_till(|c| c == '\n')(input)?;
+    let (input, _) = newline(input)?;
     Ok((input, (old_range, new_range)))
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -174,7 +174,7 @@ fn chunk_header(input: Input<'_>) -> IResult<Input<'_>, (Range, Range)> {
     let (input, new_range) = range(input)?;
     let (input, _) = tag(" @@")(input)?;
     // Ignore any additional context provied after @@ (git sometimes adds this)
-    let (input, _) = take_till(|c| c == '\n')(input)?;
+    let (input, _) = take_until("\n")(input)?;
     let (input, _) = newline(input)?;
     Ok((input, (old_range, new_range)))
 }

--- a/tests/regressions.rs
+++ b/tests/regressions.rs
@@ -1,0 +1,16 @@
+use patch::{Line, ParseError, Patch};
+
+use pretty_assertions::assert_eq;
+
+#[test]
+fn hunk_header_context_is_not_a_line_15() -> Result<(), ParseError<'static>> {
+    let sample = "\
+--- old.txt
++++ new.txt
+@@ -0,0 +0,0 @@ spoopadoop
+ x
+";
+    let patch = Patch::from_single(sample)?;
+    assert_eq!(patch.hunks[0].lines, [Line::Context("x")]);
+    Ok(())
+}


### PR DESCRIPTION
Respin of #16 and #10: stop treating hunk hints as context. save them to a new field on the hunk.