### PR TITLE
Handle newlines better

### DIFF
--- a/tests/regressions.rs
+++ b/tests/regressions.rs
@@ -14,3 +14,16 @@ fn hunk_header_context_is_not_a_line_15() -> Result<(), ParseError<'static>> {
     assert_eq!(patch.hunks[0].lines, [Line::Context("x")]);
     Ok(())
 }
+
+#[test]
+fn crlf_breaks_stuff_17() -> Result<(), ParseError<'static>> {
+    let sample = "\
+--- old.txt\r
++++ new.txt\r
+@@ -0,0 +0,0 @@ spoopadoop\r
+ x\r
+";
+    let patch = Patch::from_single(sample)?;
+    assert_eq!(patch.hunks[0].lines, [Line::Context("x")]);
+    Ok(())
+}

--- a/tests/samples/crlf.diff
+++ b/tests/samples/crlf.diff
@@ -1,0 +1,10 @@
+--- before.py
++++ after.py
+@@ -1,4 +1,4 @@
+-bacon
+-eggs
+-ham
++python
++eggy
++hamster
+ guido


### PR DESCRIPTION
Fix #17 (hopefully)

Use nom's `line_ending` and `not_line_ending` parsers to handle \n-style and \r\n-style line endings.