### PR TITLE
separate filename and metadata by tabs 🤦🏻‍♀️

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # CHANGELOG
 
 ## [Unreleased]
+### Breaking change
+- Filename parsing now expects (and renders) a tab character after the filename instead of a space character, before any metadata. Seems like all diff programs actually follow this convention, and git will even render unquoted filenames with spaces, so the previous parsing would produce incorrect results.
 
 ## [v0.6]
 ### Changed

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -183,7 +183,7 @@ impl<'a> fmt::Display for File<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         maybe_escape_quote(f, &self.path)?;
         if let Some(meta) = &self.meta {
-            write!(f, " {}", meta)?;
+            write!(f, "\t{}", meta)?;
         }
         Ok(())
     }

--- a/tests/parse_patch.rs
+++ b/tests/parse_patch.rs
@@ -77,8 +77,8 @@ fn test_parse_no_newline_indicator() -> Result<(), ParseError<'static>> {
 #[test]
 fn test_parse_timestamps() -> Result<(), ParseError<'static>> {
     let sample = "\
---- before.py 2002-02-21 23:30:39.942229878 -0800
-+++ after.py 2002-02-21 23:30:50 -0800
+--- before.py\t2002-02-21 23:30:39.942229878 -0800
++++ after.py\t2002-02-21 23:30:50 -0800
 @@ -1,4 +1,4 @@
 -bacon
 -eggs
@@ -118,8 +118,8 @@ fn test_parse_timestamps() -> Result<(), ParseError<'static>> {
 #[test]
 fn test_parse_other() -> Result<(), ParseError<'static>> {
     let sample = "\
---- before.py 08f78e0addd5bf7b7aa8887e406493e75e8d2b55
-+++ after.py e044048282ce75186ecc7a214fd3d9ba478a2816
+--- before.py\t08f78e0addd5bf7b7aa8887e406493e75e8d2b55
++++ after.py\te044048282ce75186ecc7a214fd3d9ba478a2816
 @@ -1,4 +1,4 @@
 -bacon
 -eggs
@@ -157,8 +157,8 @@ fn test_parse_other() -> Result<(), ParseError<'static>> {
 #[test]
 fn test_parse_escaped() -> Result<(), ParseError<'static>> {
     let sample = "\
---- before.py \"asdf \\\\ \\n \\t \\0 \\r \\\" \"
-+++ \"My Work/after.py\" \"My project is cool! Wow!!; SELECT * FROM USERS;\"
+--- before.py\t\"asdf \\\\ \\n \\t \\0 \\r \\\" \"
++++ \"My Work/after.py\"\t\"My project is cool! Wow!!; SELECT * FROM USERS;\"
 @@ -1,4 +1,4 @@
 -bacon
 -eggs

--- a/tests/regressions.rs
+++ b/tests/regressions.rs
@@ -1,4 +1,4 @@
-use patch::{File, Hunk, Line, ParseError, Patch, Range};
+use patch::{File, FileMetadata, Hunk, Line, ParseError, Patch, Range};
 
 use pretty_assertions::assert_eq;
 
@@ -42,6 +42,32 @@ fn crlf_breaks_stuff_17() -> Result<(), ParseError<'static>> {
                 lines: vec![Line::Context("x")],
             }],
             end_newline: true,
+        }
+    );
+    Ok(())
+}
+
+#[test]
+fn unquoted_filenames_with_spaces_11() -> Result<(), ParseError<'static>> {
+    let sample = "\
+--- unquoted no space\t
++++ unquoted no space\twith metadata
+@@ -0,0 +0,0 @@
+ x
+";
+    let patch = Patch::from_single(sample)?;
+    assert_eq!(
+        patch.old,
+        File {
+            path: "unquoted no space".into(),
+            meta: None,
+        }
+    );
+    assert_eq!(
+        patch.new,
+        File {
+            path: "unquoted no space".into(),
+            meta: Some(FileMetadata::Other("with metadata".into())),
         }
     );
     Ok(())


### PR DESCRIPTION
soooooooooooooo thank you @keith for raising this in #11. turns out _every_ sample diff uses a tab character to separate the filename. git definitely always does. i haven't yet found any counter-examples (except those generated from this library 🤦🏻‍♀️🤦🏻‍♀️🤦🏻‍♀️).

well, there's one very annoying counter-example: one of the examples on gnu.org's written description of the format.

- full example (uses tabs): https://www.gnu.org/software/diffutils/manual/html_node/Example-Unified.html
- detailed description (uses spaces 😠): https://www.gnu.org/software/diffutils/manual/html_node/Detailed-Unified.html

i'm going to assume that the detailed description contains an error and ignore it 🙃. this library will switch to expect (and render) a tab character. not sure how else to handle it, but if new counter-examples come up, i'll think about thinking more about it. with thoughts.

fixes #11. breaking change.