### PR TITLE
[proposal] Add generic string parameter to types

### DIFF
--- a/examples/apply.rs
+++ b/examples/apply.rs
@@ -1,20 +1,21 @@
 //! Demonstrates how to apply a parsed diff to a file
 
 use patch::{Line, Patch};
+use std::borrow::Cow;
 
-fn apply(diff: Patch, old: &str) -> String {
+fn apply(diff: Patch<Cow<str>>, old: &str) -> String {
     let old_lines = old.lines().collect::<Vec<&str>>();
     let mut out: Vec<&str> = vec![];
     let mut old_line = 0;
-    for hunk in diff.hunks {
+    for hunk in &diff.hunks {
         while old_line < hunk.old_range.start - 1 {
             out.push(old_lines[old_line as usize]);
             old_line += 1;
         }
         old_line += hunk.old_range.count;
-        for line in hunk.lines {
+        for line in &hunk.lines {
             match line {
-                Line::Add(s) | Line::Context(s) => out.push(s),
+                Line::Add(s) | Line::Context(s) => out.push(s.as_ref()),
                 Line::Remove(_) => {}
             }
         }

--- a/tests/regressions.rs
+++ b/tests/regressions.rs
@@ -1,4 +1,4 @@
-use patch::{File, FileMetadata, Hunk, Line, ParseError, Patch, Range};
+use patch::{File, FileMetadata, Hunk, IntoS, Line, ParseError, Patch, Range};
 
 use pretty_assertions::assert_eq;
 
@@ -11,7 +11,7 @@ fn hunk_header_context_is_not_a_line_15() -> Result<(), ParseError<'static>> {
  x
 ";
     let patch = Patch::from_single(sample)?;
-    assert_eq!(patch.hunks[0].lines, [Line::Context("x")]);
+    assert_eq!(patch.hunks[0].lines, [Line::Context("x").into_s()]);
     Ok(())
 }
 
@@ -43,6 +43,7 @@ fn crlf_breaks_stuff_17() -> Result<(), ParseError<'static>> {
             }],
             end_newline: true,
         }
+        .into_s()
     );
     Ok(())
 }


### PR DESCRIPTION
- Add generic string parameter to the following types:
  - `Patch<'a>` -> `Patch<S>`
  - `File<'a>` -> `File<S>`
  - `Hunk<'a>` -> `Hunk<S>`
  - `Line<'a>` -> `Line<S>`
This make it possible to do that types self owned when needed.

- Add `FromS<T>` and `IntoS<T>` traits. This traits is same as core traits `From<T>` and `Into<T>`. It needs due to compiler constraints which is not allow add generic implementations for core traits.

Have any ideas how to avoid adding `FromS`/`IntoS`?