### PR TITLE
Updated dependencies and added an applier module for apply patches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,9 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
-nom = "7.1.0"
-nom_locate = "4.0.0"
-chrono = "0.4.19"
+nom = "8.0.0"
+nom_locate = "5.0.0"
+chrono = "0.4.40"
 
 [dev-dependencies]
-pretty_assertions = "1.0.0"
+pretty_assertions = "1.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/uniphil/patch-rs"
 readme = "README.md"
 keywords = ["patch", "diff", "parse", "nom"]
 license = "MIT"
-edition = "2018"
+edition = "2024"
 
 [dependencies]
 nom = "8.0.0"

--- a/src/applier.rs
+++ b/src/applier.rs
@@ -1,0 +1,273 @@
+use std::error::Error;
+use std::fmt;
+
+use crate::ast::{Line, Patch};
+
+/// Error that can occur while applying a patch
+#[derive(Debug)]
+pub enum ApplyError {
+    /// The line number in the patch is out of bounds for the input text
+    LineOutOfBounds {
+        /// The line number that was out of bounds
+        line: u64,
+        /// The total number of lines in the input text
+        total_lines: usize,
+    },
+    /// The context lines in the patch don't match the input text
+    ContextMismatch {
+        /// The line number where the mismatch occurred
+        line: u64,
+        /// The expected context line from the patch
+        expected: String,
+        /// The actual line from the input text
+        actual: String,
+    },
+}
+
+impl fmt::Display for ApplyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ApplyError::LineOutOfBounds { line, total_lines } => {
+                write!(
+                    f,
+                    "Line {} is out of bounds (file has {} lines)",
+                    line, total_lines
+                )
+            }
+            ApplyError::ContextMismatch {
+                line,
+                expected,
+                actual,
+            } => {
+                write!(
+                    f,
+                    "Context mismatch at line {}: expected '{}', got '{}'",
+                    line, expected, actual
+                )
+            }
+        }
+    }
+}
+
+impl Error for ApplyError {}
+
+/// Apply a patch to the given text content
+///
+/// # Arguments
+///
+/// * `patch` - The patch to apply
+/// * `content` - The text content to apply the patch to
+///
+/// # Returns
+///
+/// The patched text content if successful, or an error if the patch cannot be applied
+///
+/// # Example
+///
+/// ```
+/// use patch::{Patch, apply};
+///
+/// let content = "line 1\nline 2\nline 3\n";
+/// let patch_text = "\
+/// --- old.txt
+/// +++ new.txt
+/// @@ -1,3 +1,3 @@
+///  line 1
+/// -line 2
+/// +new line 2
+///  line 3
+/// ";
+///
+/// let patch = Patch::from_single(patch_text).unwrap();
+/// let result = apply(&patch, content).unwrap();
+/// assert_eq!(result, "line 1\nnew line 2\nline 3\n");
+/// ```
+pub fn apply(patch: &Patch, content: &str) -> Result<String, ApplyError> {
+    let lines: Vec<&str> = content.lines().collect();
+    let mut result = Vec::new();
+    let mut current_line = 0;
+
+    for hunk in &patch.hunks {
+        // Add unchanged lines before the hunk
+        while current_line < (hunk.old_range.start - 1) as usize {
+            if current_line >= lines.len() {
+                return Err(ApplyError::LineOutOfBounds {
+                    line: current_line as u64 + 1,
+                    total_lines: lines.len(),
+                });
+            }
+            result.push(lines[current_line].to_string());
+            current_line += 1;
+        }
+
+        let mut hunk_old_line = current_line;
+        for line in &hunk.lines {
+            match line {
+                Line::Context(text) => {
+                    if hunk_old_line >= lines.len() {
+                        return Err(ApplyError::LineOutOfBounds {
+                            line: hunk_old_line as u64 + 1,
+                            total_lines: lines.len(),
+                        });
+                    }
+                    if lines[hunk_old_line] != *text {
+                        return Err(ApplyError::ContextMismatch {
+                            line: hunk_old_line as u64 + 1,
+                            expected: text.to_string(),
+                            actual: lines[hunk_old_line].to_string(),
+                        });
+                    }
+                    result.push(text.to_string());
+                    hunk_old_line += 1;
+                }
+                Line::Add(text) => {
+                    result.push(text.to_string());
+                }
+                Line::Remove(text) => {
+                    if hunk_old_line >= lines.len() {
+                        return Err(ApplyError::LineOutOfBounds {
+                            line: hunk_old_line as u64 + 1,
+                            total_lines: lines.len(),
+                        });
+                    }
+                    if lines[hunk_old_line] != *text {
+                        return Err(ApplyError::ContextMismatch {
+                            line: hunk_old_line as u64 + 1,
+                            expected: text.to_string(),
+                            actual: lines[hunk_old_line].to_string(),
+                        });
+                    }
+                    hunk_old_line += 1;
+                }
+            }
+        }
+        current_line = hunk_old_line;
+    }
+
+    // Add any remaining lines after the last hunk
+    while current_line < lines.len() {
+        result.push(lines[current_line].to_string());
+        current_line += 1;
+    }
+
+    // Handle the end newline based on the patch's end_newline flag
+    let mut output = result.join("\n");
+    if !output.is_empty() && patch.end_newline {
+        output.push('\n');
+    }
+
+    Ok(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Patch;
+
+    #[test]
+    fn test_apply_simple_patch() {
+        let content = "line 1\nline 2\nline 3\n";
+        let patch_text = "\
+--- old.txt
++++ new.txt
+@@ -1,3 +1,3 @@
+ line 1
+-line 2
++new line 2
+ line 3
+";
+        let patch = Patch::from_single(patch_text).unwrap();
+        let result = apply(&patch, content).unwrap();
+        assert_eq!(result, "line 1\nnew line 2\nline 3\n");
+    }
+
+    #[test]
+    fn test_apply_patch_with_additions() {
+        let content = "A\nB\nC\n";
+        let patch_text = "\
+--- old.txt
++++ new.txt
+@@ -1,3 +1,5 @@
+ A
++X
+ B
++Y
+ C
+";
+        let patch = Patch::from_single(patch_text).unwrap();
+        let result = apply(&patch, content).unwrap();
+        assert_eq!(result, "A\nX\nB\nY\nC\n");
+    }
+
+    #[test]
+    fn test_apply_patch_with_removals() {
+        let content = "A\nB\nC\nD\n";
+        let patch_text = "\
+--- old.txt
++++ new.txt
+@@ -1,4 +1,2 @@
+ A
+-B
+-C
+ D
+";
+        let patch = Patch::from_single(patch_text).unwrap();
+        let result = apply(&patch, content).unwrap();
+        assert_eq!(result, "A\nD\n");
+    }
+
+
+    #[test]
+    fn test_apply_patch_line_out_of_bounds() {
+        let content = "A\nB\n";
+        let patch_text = "\
+--- old.txt
++++ new.txt
+@@ -1,3 +1,3 @@
+ A
+ B
+-C
++D
+";
+        let patch = Patch::from_single(patch_text).unwrap();
+        let err = apply(&patch, content).unwrap_err();
+        match err {
+            ApplyError::LineOutOfBounds {
+                line,
+                total_lines,
+            } => {
+                assert_eq!(line, 3);
+                assert_eq!(total_lines, 2);
+            }
+            _ => panic!("Expected LineOutOfBounds error"),
+        }
+    }
+
+    #[test]
+    fn test_apply_patch_context_mismatch() {
+        let content = "A\nB\nC\n";
+        let patch_text = "\
+--- old.txt
++++ new.txt
+@@ -1,3 +1,3 @@
+ A
+-X
++Y
+ C
+";
+        let patch = Patch::from_single(patch_text).unwrap();
+        let err = apply(&patch, content).unwrap_err();
+        match err {
+            ApplyError::ContextMismatch {
+                line,
+                expected,
+                actual,
+            } => {
+                assert_eq!(line, 2);
+                assert_eq!(expected, "X");
+                assert_eq!(actual, "B");
+            }
+            _ => panic!("Expected ContextMismatch error"),
+        }
+    }
+} 

--- a/src/applier.rs
+++ b/src/applier.rs
@@ -1,8 +1,7 @@
-use nom::Err;
 use std::fmt;
-use std::{error::Error, ops::Index};
+use std::error::Error;
 
-use crate::ast::{Hunk, Line, Patch, Range};
+use crate::ast::{Line, Patch};
 
 /// Error that can occur while applying a patch
 #[derive(Debug)]
@@ -171,7 +170,20 @@ pub fn apply(patch: &Patch, content: &str) -> Result<String, ApplyError> {
     Ok(output)
 }
 
-fn find_replace_apply(patch: &Patch, content: &str) -> Result<String, ApplyError> {
+/// Applies a patch to content using a find-and-replace strategy.
+///
+/// Unlike the standard `apply` function, this method doesn't rely on exact line numbers.
+/// Instead, it searches for blocks of context and removed lines that match the patch,
+/// and replaces them with the corresponding new lines.
+///
+/// # Arguments
+/// * `patch` - The patch to apply
+/// * `content` - The content to apply the patch to
+///
+/// # Returns
+/// * `Ok(String)` - The patched content
+/// * `Err(ApplyError)` - If the patch couldn't be applied
+pub fn find_replace_apply(patch: &Patch, content: &str) -> Result<String, ApplyError> {
     // Split the content into lines.
     let mut content_lines: Vec<&str> = content.lines().collect();
 

--- a/src/applier.rs
+++ b/src/applier.rs
@@ -1,5 +1,5 @@
-use std::fmt;
 use std::error::Error;
+use std::fmt;
 
 use crate::ast::{Line, Patch};
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -21,7 +21,7 @@ pub struct Patch<'a> {
     pub end_newline: bool,
 }
 
-impl<'a> fmt::Display for Patch<'a> {
+impl fmt::Display for Patch<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // Display implementations typically hold up the invariant that there is no trailing
         // newline. This isn't enforced, but it allows them to work well with `println!`
@@ -179,7 +179,7 @@ pub struct File<'a> {
     pub meta: Option<FileMetadata<'a>>,
 }
 
-impl<'a> fmt::Display for File<'a> {
+impl fmt::Display for File<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         maybe_escape_quote(f, &self.path)?;
         if let Some(meta) = &self.meta {
@@ -198,7 +198,7 @@ pub enum FileMetadata<'a> {
     Other(Cow<'a, str>),
 }
 
-impl<'a> fmt::Display for FileMetadata<'a> {
+impl fmt::Display for FileMetadata<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             FileMetadata::DateTime(datetime) => {
@@ -222,7 +222,7 @@ pub struct Hunk<'a> {
     pub lines: Vec<Line<'a>>,
 }
 
-impl<'a> Hunk<'a> {
+impl Hunk<'_> {
     /// A nicer way to access the optional hint
     pub fn hint(&self) -> Option<&str> {
         let h = self.range_hint.trim_start();
@@ -234,7 +234,7 @@ impl<'a> Hunk<'a> {
     }
 }
 
-impl<'a> fmt::Display for Hunk<'a> {
+impl fmt::Display for Hunk<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
@@ -276,7 +276,7 @@ pub enum Line<'a> {
     Context(&'a str),
 }
 
-impl<'a> fmt::Display for Line<'a> {
+impl fmt::Display for Line<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Line::Add(line) => write!(f, "+{}", line),

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -3,7 +3,7 @@ use std::fmt;
 
 use chrono::{DateTime, FixedOffset};
 
-use crate::parser::{parse_multiple_patches, parse_single_patch, ParseError};
+use crate::parser::{ParseError, parse_multiple_patches, parse_single_patch};
 
 /// A complete patch summarizing the differences between two files
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -226,11 +226,7 @@ impl Hunk<'_> {
     /// A nicer way to access the optional hint
     pub fn hint(&self) -> Option<&str> {
         let h = self.range_hint.trim_start();
-        if h.is_empty() {
-            None
-        } else {
-            Some(h)
-        }
+        if h.is_empty() { None } else { Some(h) }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,6 @@ mod applier;
 mod ast;
 mod parser;
 
-pub use applier::{ApplyError, apply};
+pub use applier::{ApplyError, apply, find_replace_apply};
 pub use ast::*;
 pub use parser::ParseError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,10 +45,10 @@
 
 #![deny(unused_must_use)]
 
-mod ast;
 mod applier;
+mod ast;
 mod parser;
 
+pub use applier::{ApplyError, apply};
 pub use ast::*;
 pub use parser::ParseError;
-pub use applier::{apply, ApplyError};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,9 @@
 #![deny(unused_must_use)]
 
 mod ast;
+mod applier;
 mod parser;
 
 pub use ast::*;
 pub use parser::ParseError;
+pub use applier::{apply, ApplyError};

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -45,7 +45,7 @@ impl<'a> From<nom::Err<nom::error::Error<Input<'a>>>> for ParseError<'a> {
     }
 }
 
-impl<'a> std::fmt::Display for ParseError<'a> {
+impl std::fmt::Display for ParseError<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(
             f,
@@ -55,7 +55,7 @@ impl<'a> std::fmt::Display for ParseError<'a> {
     }
 }
 
-impl<'a> Error for ParseError<'a> {
+impl Error for ParseError<'_> {
     fn description(&self) -> &str {
         self.kind.description()
     }


### PR DESCRIPTION
### Description

This PR introduces several updates and enhancements to the `patch-rs` library, improving its functionality, compatibility, and modernity. The key changes are as follows:

#### 1. Rust Edition Update
- **Change:** Updated the Rust edition from `"2018"` to `"2024"` in `Cargo.toml`.
- **Purpose:** This allows the project to leverage the latest Rust language features, improvements, and best practices introduced up to the 2024 edition.

#### 2. Dependency Updates
- **Updated Dependencies:**
  - `nom`: `7.1.0` → `8.0.0`
  - `nom_locate`: `4.0.0` → `5.0.0`
  - `chrono`: `0.4.19` → `0.4.40`
  - `pretty_assertions`: `1.0.0` → `1.4.1`
- **Purpose:** These updates bring bug fixes, performance improvements, and new features from the latest versions of these libraries, ensuring the project remains current and efficient.

#### 3. New Feature: Patch Application
- **Addition:** Introduced a new module `src/applier.rs`.
- **Details:**
  - **Functionality:** Adds the `apply` function, which takes a `Patch` and text content as input, applies the patch, and returns the modified content.
  - **Error Handling:** Defines an `ApplyError` enum to manage errors such as:
    - `LineOutOfBounds`: When a line number exceeds the input text's bounds.
    - `ContextMismatch`: When context lines in the patch don’t match the input text.
  - **Implementation:** The `apply` function processes patch hunks, handles context/add/remove lines, respects the `end_newline` flag, and includes thorough tests for various scenarios (e.g., simple patches, additions, removals, and error cases).
- **Public API:** Exposed via `pub use applier::{apply, ApplyError};` in `src/lib.rs`.
- **Purpose:** This extends the library’s capabilities beyond parsing patches to applying them, making it more versatile for users working with diff files.

#### 4. Parser Adjustments for `nom` v8 Compatibility
- **Change:** Updated parser code in `src/parser.rs` to align with `nom` version 8’s API.
- **Details:**
  - **Old Style:** Combinators like `many1(patch)(input)` directly returned results.
  - **New Style:** Combinators now return a `Parser` type, requiring explicit `.parse(input)` calls (e.g., `let mut parser = many1(patch); parser.parse(input)`).
- **Purpose:** Ensures compatibility with the updated `nom` dependency, adapting to its modern API design.

#### 5. Code Modernization
- **Change:** Updated lifetime annotations in `impl fmt::Display` blocks across `src/ast.rs` and `src/parser.rs`.
- **Details:** Replaced explicit lifetime parameters (e.g., `impl<'a> fmt::Display for Patch<'a>`) with the concise `'_` syntax (e.g., `impl fmt::Display for Patch<'_>`).
- **Purpose:** Improves code readability and aligns with modern Rust conventions.